### PR TITLE
More closely replicate SourceMod's menu

### DIFF
--- a/CS2ScreenMenuAPI.csproj
+++ b/CS2ScreenMenuAPI.csproj
@@ -6,9 +6,8 @@
 		<Nullable>enable</Nullable>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-		<OutputPath>bin\Release\addons\counterstrikesharp\shared\CS2ScreenMenuAPI\</OutputPath>
+		<OutputPath>bin\$(Configuration)\addons\counterstrikesharp\shared\CS2ScreenMenuAPI\</OutputPath>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<Configuration>Release</Configuration>
 		<DebugType>none</DebugType>
 	</PropertyGroup>
 

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -207,7 +207,8 @@ ScrollDown = ""menu.ScrollDown""
 Volume = 1.0
 
 [Lang.en]
-Prev = ""Back""
+Back = ""Back""
+Prev = ""Previous""
 Next = ""Next""
 Close = ""Close""
 ScrollKeys = ""[{0}/{1}] Scroll""


### PR DESCRIPTION
Changes:
- Allow one more items per page when screen resolution is disabled This makes exit 0 instead of 9
- Put controls on a single line for brevity
- Refactored how the menu strings append text
- Items in the last page menu will remain expanded
- Differentiate between Back and Previous buttons
- If either back/prev or next is present, disabled versions leave an empty line
- Add an empty line between items and navigations
- Make Exit button background text

Bugfixes:
- Always read keys from configuration incase a menu is forced
- Fixed maxTextLength incorrectly accumulating causing the box to be too wide
- Freeze the player via setting their speed to 0
- Fix empty line at the end causing the background to be too tall

Some images of how it looks with SimpleAdmin (API being translated):

![SimpleMenu](https://github.com/user-attachments/assets/6f94d6fc-f05c-4221-954f-de765efaf65b)

![ServerManageMenu](https://github.com/user-attachments/assets/8664e6e6-aa1d-4e74-9a37-d3f44ee9bad2)

![FunCommandsMenu1](https://github.com/user-attachments/assets/31cb5649-ea96-4d29-80c5-0deadc310111)

![FunCommandsMenu2](https://github.com/user-attachments/assets/a6e211f1-5c90-4868-bbff-ee5774443a74)
